### PR TITLE
Enhance DisplayManager to support multiple Heltec board versions

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -54,6 +54,11 @@
 #define DISPLAY_ENABLED true
 #define DISPLAY_TIMEOUT 30000  // Turn off display after this many ms of inactivity
 
+// Heltec board version
+// 0 = V3.0/V3.1 (normal VEXT)
+// 1 = V3.2 (inverted VEXT)
+#define HELTEC_BOARD_VERSION 1  // Set to 1 for V3.2 boards, 0 for V3.0/V3.1 boards
+
 // ===== OLED Display Configuration =====
 #define OLED_SDA 17
 #define OLED_SCL 18

--- a/lib/DisplayManager/README.md
+++ b/lib/DisplayManager/README.md
@@ -14,6 +14,7 @@ A comprehensive library for managing OLED displays on ESP32 boards, specifically
   - System logs
   - Error messages
 - Integrated logging system with serial output support
+- Support for multiple Heltec board versions, including V3.2 with inverted VEXT pin
 
 ## Installation
 
@@ -23,7 +24,24 @@ A comprehensive library for managing OLED displays on ESP32 boards, specifically
 ## Hardware Requirements
 
 - ESP32 board with an SSD1306 OLED display (default pins SDA=17, SCL=18, RST=21)
-- Compatible with Heltec WiFi LoRa 32 V3 boards
+- Compatible with Heltec WiFi LoRa 32 V3 boards (including V3.0, V3.1, and V3.2)
+
+## Board Versions
+
+The library supports different versions of Heltec WiFi LoRa 32 boards:
+
+- `V3_0`: Original V3.0 and V3.1 boards
+- `V3_2`: Newer V3.2 boards with inverted VEXT pin
+
+When initializing the display, specify the correct board version to ensure proper display operation:
+
+```cpp
+// For older V3.0/V3.1 boards
+display.begin(-1, -1, DisplayManager::V3_0);
+
+// For newer V3.2 boards
+display.begin(-1, -1, DisplayManager::V3_2);
+```
 
 ## Dependencies
 

--- a/lib/DisplayManager/include/DisplayManager.h
+++ b/lib/DisplayManager/include/DisplayManager.h
@@ -17,6 +17,12 @@ public:
     static const int SCREEN_HEIGHT = 64;
     static const int LINE_HEIGHT = 10;
     static const int MAX_LOG_LINES = 10;
+    
+    // Heltec board versions
+    enum BoardVersion {
+        V3_0, // V3.0 or V3.1
+        V3_2  // V3.2 (inverted VEXT)
+    };
 
     /**
      * @brief Constructor
@@ -28,8 +34,17 @@ public:
      * 
      * @param sda SDA pin (pass -1 to use default)
      * @param scl SCL pin (pass -1 to use default)
+     * @param boardVersion Board version (V3_0 for V3.0/V3.1, V3_2 for V3.2)
      */
-    void begin(int sda = -1, int scl = -1);
+    void begin(int sda = -1, int scl = -1, BoardVersion boardVersion = V3_0);
+    
+    /**
+     * @brief Control VEXT power pin for display
+     * 
+     * @param state true to enable display power, false to disable
+     * @param inverted true for V3.2 boards where VEXT is inverted, false for other boards
+     */
+    void controlDisplayPower(bool state, bool inverted = false);
     
     /**
      * @brief Clear the display

--- a/lib/DisplayManager/library.json
+++ b/lib/DisplayManager/library.json
@@ -1,6 +1,6 @@
 {
     "name": "DisplayManager",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A comprehensive OLED display manager for ESP32 boards, especially for Heltec WiFi LoRa 32 devices",
     "keywords": "display, oled, esp32, lora, heltec, logger",
     "repository": {

--- a/lib/DisplayManager/src/DisplayManager.cpp
+++ b/lib/DisplayManager/src/DisplayManager.cpp
@@ -4,6 +4,7 @@
 #define DEFAULT_OLED_SDA 17
 #define DEFAULT_OLED_SCL 18
 #define DEFAULT_OLED_RST 21
+#define VEXT_PIN 36  // VEXT control pin on Heltec boards (GPIO36)
 
 DisplayManager::DisplayManager() : 
     u8g2(U8G2_R0, DEFAULT_OLED_SCL, DEFAULT_OLED_SDA, DEFAULT_OLED_RST),
@@ -16,7 +17,24 @@ DisplayManager::DisplayManager() :
     }
 }
 
-void DisplayManager::begin(int sda, int scl) {
+void DisplayManager::controlDisplayPower(bool state, bool inverted) {
+    pinMode(VEXT_PIN, OUTPUT);
+    
+    // For V3.2 boards, VEXT is inverted (LOW turns on the display, HIGH turns it off)
+    // For older boards, VEXT is normal (LOW turns off the display, HIGH turns it on)
+    if (inverted) {
+        digitalWrite(VEXT_PIN, state ? LOW : HIGH);
+    } else {
+        digitalWrite(VEXT_PIN, state ? HIGH : LOW);
+    }
+    
+    delay(10); // Small delay to ensure power stabilizes
+}
+
+void DisplayManager::begin(int sda, int scl, BoardVersion boardVersion) {
+    // Control display power based on board version
+    controlDisplayPower(true, boardVersion == V3_2);
+    
     // Initialize the OLED display
     if (sda != -1 && scl != -1) {
         u8g2.setBusClock(400000);  // Set I2C clock speed to 400kHz

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ void setup() {
   }
   
   // Initialize display with startup screen
-  display.begin();
+  display.begin(-1, -1, HELTEC_BOARD_VERSION == 1 ? DisplayManager::V3_2 : DisplayManager::V3_0);
   display.setNormalMode(); // Ensure display is in normal mode
   display.drawStartupScreen();
   display.updateStartupProgress(10, "Initializing...");

--- a/test/test_display_manager.cpp
+++ b/test/test_display_manager.cpp
@@ -11,18 +11,18 @@ void tearDown(void) {
 
 void test_display_initialization() {
     DisplayManager display;
-    TEST_ASSERT_TRUE(display.begin());
+    TEST_ASSERT_TRUE(display.begin(-1, -1, DisplayManager::V3_0));
 }
 
 void test_display_update() {
     DisplayManager display;
-    display.begin();
+    display.begin(-1, -1, DisplayManager::V3_0);
     TEST_ASSERT_TRUE(display.update());
 }
 
 void test_display_clear() {
     DisplayManager display;
-    display.begin();
+    display.begin(-1, -1, DisplayManager::V3_0);
     display.clear();
     TEST_ASSERT_TRUE(true); // Add specific display state verification
 }


### PR DESCRIPTION
- Added HELTEC_BOARD_VERSION configuration in Config.h to specify board type.
- Updated library.json to version 1.1.0 to reflect new features.
- Expanded README.md to include support details for V3.0, V3.1, and V3.2 boards.
- Modified DisplayManager.h and DisplayManager.cpp to implement board version handling.
- Adjusted main.cpp to initialize display based on the specified board version.
- Updated tests in test_display_manager.cpp to accommodate new initialization parameters.